### PR TITLE
fix: cherrypick gossip fix

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -1,0 +1,54 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry should ideally include a tag and
+the Github issue reference in the following format:
+
+* (<tag>) \#<issue-number> message
+
+The issue numbers will later be link-ified during the release process so you do
+not have to worry about including a link manually, but you can if you wish.
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking CLI commands and REST routes.
+"State Machine Breaking" for breaking the AppState
+
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+# Changelog
+
+## [Unreleased]
+
+## [v0.34.23-alpha.agoric.2]
+
+* Agoric/agoric-sdk\#6945 Cherrypick fix for informalsystems/tendermint#4.
+
+## [v0.34.23-alpha.agoric.1]
+
+* Agoric/agoric-sdk\#6305 Merge `tendermint/tendermint` v0.34.23
+
+## [v0.34.21-alpha.agoric.1]
+
+* Agoric/agoric-sdk\#6305 Merge `tendermint/tendermint` v0.34.21.
+
+## [v0.34.14-alpha.agoric.1]
+
+* Merge `tendermint/tendermint` v0.34.23.
+* Add committing client for greater query concurrency.

--- a/consensus/reactor.go
+++ b/consensus/reactor.go
@@ -706,6 +706,8 @@ func (conR *Reactor) gossipDataForCatchup(logger log.Logger, rs *cstypes.RoundSt
 			ps.SetHasProposalBlockPart(prs.Height, prs.Round, index)
 		} else {
 			logger.Debug("Sending block part for catchup failed")
+			// sleep to avoid retrying too fast
+			time.Sleep(conR.conS.config.PeerGossipSleepDuration)
 		}
 		return
 	}


### PR DESCRIPTION
## Description

Closes: Agoric/agoric-sdk#6945

Cherrypick informalsystems/tendermint#245 to fix issue described in informalsystems/tendermint#4.

Once merged, will tag as `v0.34.23-alpha.agoric.2`.

