### PR TITLE
chore: lower default `BlockParams.MaxBytes`

### DIFF
--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -36,9 +36,13 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
-## [v0.34.23-alpha.agoric.2]
+## [v0.34.23-alpha.agoric.3]
 
 * Agoric/agoric-sdk\#6945 Cherrypick fix for informalsystems/tendermint#4.
+
+## [v0.34.23-alpha.agoric.2]
+
+* Adapt to new callback tracking. See tendermint/tendermint#8331
 
 ## [v0.34.23-alpha.agoric.1]
 

--- a/CHANGELOG-Agoric.md
+++ b/CHANGELOG-Agoric.md
@@ -36,6 +36,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## [Unreleased]
 
+## [v0.34.23-alpha.agoric.4]
+
+* Lower default `BlockParams.MaxBytes` to 5MB to mitigate asa-2023-002 
+
 ## [v0.34.23-alpha.agoric.3]
 
 * Agoric/agoric-sdk\#6945 Cherrypick fix for informalsystems/tendermint#4.

--- a/types/params.go
+++ b/types/params.go
@@ -34,7 +34,7 @@ func DefaultConsensusParams() *tmproto.ConsensusParams {
 // DefaultBlockParams returns a default BlockParams.
 func DefaultBlockParams() tmproto.BlockParams {
 	return tmproto.BlockParams{
-		MaxBytes:   22020096, // 21MB
+		MaxBytes:   5 * 1024 * 1024, // 5MB
 		MaxGas:     -1,
 		TimeIotaMs: 1000, // 1s
 	}


### PR DESCRIPTION
Refs: https://github.com/Agoric/agoric-sdk/issues/8483

## Description

Adopts one of the [mitigation suggested by Notional](https://github.com/notional-labs/placid/blob/main/README.md#mitigations) for [asa-2023-002](https://forum.cosmos.network/t/amulet-security-advisory-for-cometbft-asa-2023-002/11604).

There is currently a pending PR on comet bft with a proposed similar change: `https://github.com/cometbft/cometbft/pull/1518` (not linking as that issue is somewhat contentious)
